### PR TITLE
Scrollbars에 universal prop 추가

### DIFF
--- a/app/common/CustomScrollbars.tsx
+++ b/app/common/CustomScrollbars.tsx
@@ -6,6 +6,7 @@ import styles from './component.module.css'
 export default function CustomScrollbars({children}: {children: ReactNode}) {
     return (
       <Scrollbars
+        universal
         thumbSize={50}
         renderTrackHorizontal={props => <div {...props} className={styles.track_horizontal}/>}
         renderTrackVertical={props => <div {...props} className={styles.track_vertical}/>}

--- a/app/common/ScrolledHalfBoard.tsx
+++ b/app/common/ScrolledHalfBoard.tsx
@@ -37,12 +37,12 @@ export default function ScrolledHalfBoard({ columns, items }: { columns: Array<R
 
     return (
         <Box width="45%" height="100%" overflowY={'auto'}>
-            {/* <CustomScrollbars> */}
+            <CustomScrollbars>
                 <Table.Root unstyled className={styles.table}>
                     {getTableHeader(columns)}
                     {getTableBody(items)}
                 </Table.Root>
-            {/* </CustomScrollbars> */}
+            </CustomScrollbars>
         </Box>
     )
 }


### PR DESCRIPTION
CustomScrollbars 컴포넌트 사용시 Refresh 후 아래와 같은 에러 발생
```
Error: A tree hydrated but some attributes of the server rendered HTML didn't match the client properties. This won't be patched up. This can happen if a SSR-ed Client Component used:

- A server/client branch `if (typeof window !== 'undefined')`.
- Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
- Date formatting in a user's locale which doesn't match the server.
- External changing data without sending a snapshot of it along with the HTML.
- Invalid HTML tag nesting.

It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
```

Client-side, Server-side에서 동시에 rendering시 mismatch로 발생하는 에러로, `universal` prop 추가로 해결
https://github.com/malte-wessel/react-custom-scrollbars/blob/master/docs/usage.md#universal-rendering