### PR TITLE
화면 축소시 잘림 현상 수정

### DIFF
--- a/app/common/board/Board.tsx
+++ b/app/common/board/Board.tsx
@@ -11,6 +11,7 @@ import {
 import {
     PaginationItems,
     PaginationNextTrigger,
+    PaginationPageText,
     PaginationPrevTrigger,
     PaginationRoot,
   } from "@/components/ui/pagination"
@@ -121,9 +122,9 @@ export default function Board({ boards, totalCount, pageState }: { boards: Array
                     siblingCount={3}
                 >
                     <HStack wrap="wrap">
-                    <PaginationPrevTrigger color="black"/>
-                    <PaginationItems color="black"/>
-                    <PaginationNextTrigger color="black"/>
+                        <PaginationPageText format="long" flex="1" color="black"/>
+                        <PaginationPrevTrigger color="black"/>
+                        <PaginationNextTrigger color="black"/>
                     </HStack>
                 </PaginationRoot>
             </Box>

--- a/app/layout/layout.module.css
+++ b/app/layout/layout.module.css
@@ -3,11 +3,12 @@
     width: calc(100vw - var(--scrollbar-width));
     height: 100vh;
     overflow-y: hidden;
+    min-width: 1500px;
 }
 
 .header {
     width: 100%;
-    min-width: 1202px;
+    min-width: 1500px;
     height: 75px;
     background-color: #D8D5D6;
     border-width: 1px;


### PR DESCRIPTION
- 브라우저 축소시 화면이 잘리는 현상으로 min-width를 추가하여 해결
- 긴 글자로 인해 min-width를 1202px에서 1500px로 상향
- Pagination 버튼을 심플하게 변경